### PR TITLE
Change query selector value based on #4

### DIFF
--- a/publishtodev-extension/src/popup.ts
+++ b/publishtodev-extension/src/popup.ts
@@ -26,7 +26,7 @@ const eleConfigureBtn = document.querySelector('#btnConfigure');
   };
 
   chrome.tabs.executeScript({
-    code: `document.querySelector('.body').dataset['articleId']`
+    code: `document.querySelector('#article-body').dataset['articleId']`
   }, (result) => {
     articleId = <any>result || '';
     init();


### PR DESCRIPTION
This PR is to update the query selector value from `.body` to `#article-body`, mentioned in #4.

Once this is merged, the extension gets the article ID properly.